### PR TITLE
added public admin, minting, transfer, and approval functions with full safety and governance logic

### DIFF
--- a/contracts/Stacks-Stellaris.clar
+++ b/contracts/Stacks-Stellaris.clar
@@ -155,3 +155,119 @@
         false))
 
 
+
+;;;;; PUBLIC FUNCTIONS ;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Administrative Functions
+(define-public (initialize (name (string-ascii 32)) (symbol (string-ascii 10)) (decimals uint))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (not (var-get initialized)) ERR-ALREADY-INITIALIZED)
+
+        ;; Validate name
+        (asserts! (>= (len name) u1) ERR-INVALID-AMOUNT)  ;; Ensure name is not empty
+        (asserts! (<= (len name) u32) ERR-INVALID-AMOUNT)  ;; Extra safety check for length
+
+        ;; Validate symbol
+        (asserts! (>= (len symbol) u1) ERR-INVALID-AMOUNT)  ;; Ensure symbol is not empty
+        (asserts! (<= (len symbol) u10) ERR-INVALID-AMOUNT)  ;; Extra safety check for length
+
+        ;; Validate decimals (common values are 6, 8, or 18)
+        (asserts! (<= decimals u18) ERR-INVALID-AMOUNT)  ;; Ensure decimals is reasonable
+        (asserts! (>= decimals u0) ERR-INVALID-AMOUNT)   ;; Ensure decimals is non-negative
+
+        ;; After validation, set the values
+        (var-set token-name name)
+        (var-set token-symbol symbol)
+        (var-set token-decimals decimals)
+        (var-set initialized true)
+        (ok true)))
+
+
+(define-public (set-contract-owner (new-owner principal))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (not (is-eq new-owner (var-get contract-owner))) ERR-INVALID-RECIPIENT)
+        (var-set contract-owner new-owner)
+        (ok true)))
+
+(define-public (pause)
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (var-set paused true)
+        (ok true)))
+
+(define-public (unpause)
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (var-set paused false)
+        (ok true)))
+
+;; Token Operations
+(define-public (mint (amount uint) (recipient principal))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (is-valid-recipient recipient) ERR-INVALID-RECIPIENT)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+
+        (let ((new-supply (try! (safe-add (var-get total-supply) amount))))
+            (asserts! (<= new-supply MAX-SUPPLY) ERR-MAX-SUPPLY-REACHED)
+
+            (try! (ft-mint? stellar amount recipient))
+            (var-set total-supply new-supply)
+
+            (map-set governance-tokens
+                { holder: recipient }
+                { 
+                    voting-power: (unwrap! (safe-add 
+                        (default-to u0 (get voting-power (map-get? governance-tokens { holder: recipient }))) 
+                        amount) ERR-OVERFLOW),
+                    last-vote-height: stacks-block-height 
+                })
+            (ok true))))
+
+(define-public (transfer (amount uint) (recipient principal))
+    (begin
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (is-valid-recipient recipient) ERR-INVALID-RECIPIENT)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+        (asserts! (not (is-locked tx-sender)) ERR-NOT-AUTHORIZED)
+
+        (let ((sender-balance (unwrap! (get-balance tx-sender) ERR-INSUFFICIENT-BALANCE)))
+            (asserts! (>= sender-balance amount) ERR-INSUFFICIENT-BALANCE)
+
+            (try! (ft-transfer? stellar amount tx-sender recipient))
+
+            (map-set governance-tokens
+                { holder: tx-sender }
+                { 
+                    voting-power: (- sender-balance amount),
+                    last-vote-height: stacks-block-height 
+                })
+
+            (map-set governance-tokens
+                { holder: recipient }
+                { 
+                    voting-power: (unwrap! (safe-add 
+                        (default-to u0 (get voting-power (map-get? governance-tokens { holder: recipient }))) 
+                        amount) ERR-OVERFLOW),
+                    last-vote-height: stacks-block-height 
+                })
+            (ok true))))
+
+(define-public (approve (amount uint) (spender principal) (expiry uint))
+    (begin
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (not (is-eq spender tx-sender)) ERR-INVALID-SPENDER)
+        (asserts! (>= expiry stacks-block-height) ERR-EXPIRED-ALLOWANCE)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+
+        (map-set allowances
+            { owner: tx-sender, spender: spender }
+            { amount: amount, expiry: expiry })
+        (ok true)))


### PR DESCRIPTION


##  Pull Request: Add Core Administrative and Token Operation Functions to `Stacks-Stellaris`

### Summary

This PR implements the core public interface for the `Stacks-Stellaris` fungible token contract. These functions establish administrative control, lifecycle state management, minting, transferring, and secure allowance approvals, enabling complete ERC-20-style functionality with additional blockchain-native enhancements.

---

### 📌 Key Functionalities Introduced

#### 🔧 **Administrative Controls**

* `initialize(name, symbol, decimals)`
  Initializes token metadata (once only). Enforces name, symbol, and decimals constraints.
* `set-contract-owner(new-owner)`
  Transfers ownership of the contract to another principal. Prevents self-assignment.
* `pause()` & `unpause()`
  Allows the owner to pause and resume all token transfers/minting operations to ensure emergency control.

---

#### 💰 **Token Supply Control**

* `mint(amount, recipient)`
  Secure minting by the contract owner. Includes max supply check, recipient validity, and governance voting-power update.

---

#### 🔄 **User Token Operations**

* `transfer(amount, recipient)`
  Standard token transfer with checks for lock status, paused state, and governance power update for sender and receiver.

* `approve(amount, spender, expiry)`
  Sets an expirable allowance for a spender to transfer on behalf of the caller. Includes checks for valid expiry and identity.

---

### 🧠 Smart Security Enhancements

* **Checks implemented:**

  * Contract must be initialized and unpaused
  * Only valid recipients are allowed
  * Overflow-protected arithmetic (`safe-add`)
  * Block-based time-locking (via `is-locked`)
  * Governance voting power updated per transfer

* **Anti-abuse constraints:**

  * Prevents approving oneself
  * Prevents minting beyond supply cap
  * Prevents zero-value and expired allowances

---
